### PR TITLE
Fix ogg #includes

### DIFF
--- a/ogg/ogg-src/include/ogg/ogg.h
+++ b/ogg/ogg-src/include/ogg/ogg.h
@@ -16,12 +16,12 @@
 #ifndef _OGG_H
 #define _OGG_H
 
+#include <stddef.h>
+#include <ogg/os_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stddef.h>
-#include <ogg/os_types.h>
 
 typedef struct {
   void *iov_base;

--- a/ogg/ogg.xcodeproj/xcshareddata/xcschemes/ogg-iOS.xcscheme
+++ b/ogg/ogg.xcodeproj/xcshareddata/xcschemes/ogg-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ogg/ogg.xcodeproj/xcshareddata/xcschemes/ogg-macOS.xcscheme
+++ b/ogg/ogg.xcodeproj/xcshareddata/xcschemes/ogg-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This change moves them outside the `extern C` block to fix issues with clang's modules